### PR TITLE
sync: No longer sleep for an extended time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -212,4 +212,4 @@ RUN apk add -U rsync
 COPY --from=openvas-heavy /usr/local/sbin/greenbone-nvt-sync /sbin/
 COPY --from=gvmd-heavy /usr/local/sbin/greenbone-*-sync /sbin/
 
-CMD /bin/sh -c "sleep $((RANDOM % 1800)) && /sbin/greenbone-nvt-sync && sleep $((RANDOM % 300)) && /sbin/greenbone-scapdata-sync && sleep $((RANDOM % 300)) && /sbin/greenbone-certdata-sync"
+CMD /bin/sh -c "/sbin/greenbone-nvt-sync && sleep $((RANDOM % 30)) && /sbin/greenbone-scapdata-sync && sleep $((RANDOM % 30)) && /sbin/greenbone-certdata-sync"


### PR DESCRIPTION
It's probably better to do this right when the container starts so that we don't have to wait that much.  This was also an old holdover from when I was working on it and got tired of getting synced every time I ran `docker-compose up`.

Closes #13.