### PR TITLE
Remove obsolete "scanning" network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,8 +121,6 @@ networks:
   internal:
     internal: true
 
-  scanning:
-
 volumes:
   postgres-data:
   postgres-socket:


### PR DESCRIPTION
This network is not used by any containers, so we don't need it around anymore.